### PR TITLE
Containerize mockoon-cli with README examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:12
+
+# Make sure that `npm run package-lin` was run before!
+COPY ./packages/lin/mockoon-cli /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:12
+FROM node:12-alpine
 
 # Make sure that `npm run package-lin` was run before!
 COPY ./packages/lin/mockoon-cli /usr/local/bin
+RUN apk add --no-cache libstdc++ libgcc

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you only want to spin up certain Mockoon environments, you have to identify t
 
 To use a specific SSL cerificate and key, alter the ssl.ts file inside the source folder and rebuild.
 
-## Packag and run elsewhere
+## Package and run elsewhere
 
 To package the tool into a single binary, run `npm run package-<mac|win|lin>` depending on your platform or use `npm run package` to create a binary for all platforms. The results will be written to the `packages` folder. Afterwards, you can invoke the binary anywhere.
 
@@ -29,3 +29,25 @@ To package the tool into a single binary, run `npm run package-<mac|win|lin>` de
 * If you only want to run certain environments, make sure that you have set an UUID for the environments in your Mockoon export. Afterwards, you can run the tool with command line argument `--run-envs=["uuid1", "uuid2", ...]` to only start the specified environments.
     
     *NOTE:* When you are using zsh, you might need to use `--run-envs='["uuid1", "uuid2", ...]'`.
+
+## Docker
+
+Since the CLI requires a Mockoon JSON file to run, it is necessary for you to build your own image.
+This image shall be the running mockoon-cli loaded with your own Mockoon JSON file.
+
+1. The Dockerfile for a basic mockoon-cli without export.json is available in this folder so you can build it yourself locally, 
+  but you can also use `andyta/mockoon-cli:latest` in step 2.
+    - If you build the image yourself with the Dockerfile, you have to run `npm run package-lin` beforehand.
+    - You can build the image yourself with `docker build --tag mockoon-cli:<version> .` in this folder.
+
+2. An example for building your own image is provided in docker/example.Dockerfile.
+    - Make sure that you have a export.json file under the docker folder which is your Mockoon JSON file.
+    - If you are using your own mockoon-cli image and not `andyta/mockoon-cli:latest`, 
+    change the first line to `mockoon-cli:<version>`, or whatever you tagged your mockoon-cli image as.
+    - If you want to change any command line arguments, modify the `ENTRYPOINT` line of the Dockerfile.
+    Otherwise, it will run all environments by default.
+
+3. Build your image with `docker build -f docker/example.Dockerfile --tag <name>:<version> .`
+
+4. Run your container with `docker run -p 3002:3002 -p 3003:3003 -d <name>:<version>`
+    - The command exposes port 3002 and 3003, if you have more or less ports, modify as needed.

--- a/docker/example.Dockerfile
+++ b/docker/example.Dockerfile
@@ -1,3 +1,4 @@
+# If you've built the base container yourself, change this to the tag of it.
 FROM andyta/mockoon-cli:latest
 
 # Ensure that export.json exists in docker folder beforehand!

--- a/docker/example.Dockerfile
+++ b/docker/example.Dockerfile
@@ -1,0 +1,13 @@
+FROM mockoon-cli:latest
+
+# Ensure that export.json exists in docker folder beforehand!
+COPY ./docker/export.json /usr/local/bin/export.json
+
+# Do not run as root.
+RUN adduser --shell /bin/sh --disabled-password --gecos "" mockoon
+RUN chown -R mockoon /usr/local/bin/export.json
+RUN chown -R mockoon /usr/local/bin/mockoon-cli
+USER mockoon
+
+WORKDIR /usr/local/bin
+ENTRYPOINT ["mockoon-cli", "--environments=export.json", "--run-all"]

--- a/docker/example.Dockerfile
+++ b/docker/example.Dockerfile
@@ -1,4 +1,4 @@
-FROM mockoon-cli:latest
+FROM andyta/mockoon-cli:latest
 
 # Ensure that export.json exists in docker folder beforehand!
 COPY ./docker/export.json /usr/local/bin/export.json


### PR DESCRIPTION
Containerize mockoon-cli.

A bit tricky since we have to provide our own export.json to it, but I provided a README that details how to build one's own Docker image with one's own export.json around a base mockoon-cli Docker image that I pre-built. 